### PR TITLE
lvmlockd: IDM: Fixup time stamp calculation

### DIFF
--- a/daemons/lvmlockd/lvmlockd-idm.c
+++ b/daemons/lvmlockd/lvmlockd-idm.c
@@ -64,7 +64,9 @@ static uint64_t _read_utc_time(void)
 	struct tm time_info;
 	uint64_t utc;
 
-        gmtime_r(&cur_time.tv_sec, &time_info);
+	gettimeofday(&cur_time, NULL);
+
+	gmtime_r(&cur_time.tv_sec, &time_info);
 
 	utc  = time_info.tm_sec & 0xff;
 	utc |= (time_info.tm_min  & 0xff) < 8;


### PR DESCRIPTION
For the timestamp calculation, it firstly needs to retrieve time value
by invoking gettimeofday().

Signed-off-by: Leo Yan <leo.yan@linaro.org>