### PR TITLE
lvmlockd: IDM: Only copy drive list from global op

### DIFF
--- a/daemons/lvmlockd/lvmlockd-idm.c
+++ b/daemons/lvmlockd/lvmlockd-idm.c
@@ -540,7 +540,10 @@ int lm_lock_idm(struct lockspace *ls, struct resource *r, int ld_mode,
 			return -EIO;
 		}
 
-		memcpy(&rdi->op, &glb_op, sizeof(struct idm_lock_op));
+		rdi->op.drive_num = glb_op.drive_num;
+		for (i = 0; i < glb_op.drive_num; i++)
+			rdi->op.drives[i] = glb_op.drives[i];
+
 	} else if (r->type == LD_RT_VG) {
 		for (i = 0; i < 32; i++) {
 			if (!ls->pvs_path[i])


### PR DESCRIPTION
Every time it will allocate lock op, for global locking it doesn't need
to copy the whole global op to the runtime op structure, and the global
op structure doesn't contain the correct locking mode and if overrides
the runtime op's content, the IDM lock manager will return errors for
unsupported mode.

This patch changes to only copy drive list from global op to runtime op
for global locking.

Signed-off-by: Leo Yan <leo.yan@linaro.org>