### PR TITLE
lvmlockd: Fix compilation error

### DIFF
--- a/daemons/lvmlockd/lvmlockd-core.c
+++ b/daemons/lvmlockd/lvmlockd-core.c
@@ -566,6 +566,8 @@ static void free_lock(struct lock *lk)
 
 static void free_ls_pvs_path(struct lockspace *ls)
 {
+	int i;
+
 	for (i = 0; i < 32; i++) {
 		if (ls->pvs_path[i]) {
 			free(ls->pvs_path[i]);


### PR DESCRIPTION
Define the local variable 'i' to fix compilation error.

Signed-off-by: Leo Yan <leo.yan@linaro.org>