### PR TITLE
test: idm: Use central script for setup and cleanup

### DIFF
--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -255,7 +255,7 @@ LIB_LVMLOCKD_CONF = \
 LIB_LOCAL = paths runner
 LIB_NOT = not
 LIB_LINK_NOT = invalid fail should
-LIB_SHARED = check aux inittest utils get lvm-wrapper
+LIB_SHARED = check aux inittest utils get lvm-wrapper idm_setup idm_cleanup
 LIB_IDM_INJECT_FAILURE = idm_inject_failure
 
 install: .tests-stamp lib/paths-installed

--- a/test/lib/idm_cleanup.sh
+++ b/test/lib/idm_cleanup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+echo -n "## cleanup devices..."
+
+for d in "${BLKSALL[@]}"; do
+	dd if=/dev/zero of="$d" bs=1MB count=1000 || true
+	wipefs -a "$d" 2>/dev/null || true
+done
+
+i=0
+for d in "${BLKSALL[@]}"; do
+	i=$((i+1))
+
+	for j in {1..20}
+	do
+		dmsetup remove /dev/TESTVG$i/foo$j || true
+	done
+
+	dmsetup remove /dev/TESTVG$i/foo || true
+	dmsetup remove /dev/TESTVG$i || true
+done

--- a/test/lib/idm_setup.sh
+++ b/test/lib/idm_setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+export BLKSALL=("/dev/sdb2" "/dev/sdb3" "/dev/sdb4" "/dev/sdb5"
+	        "/dev/sdc2" "/dev/sdc3" "/dev/sdc4" "/dev/sdc5"
+	        "/dev/sdd2" "/dev/sdd3" "/dev/sdd4" "/dev/sdd5")
+
+export BLKS=("/dev/sdb2" "/dev/sdb3" "/dev/sdb4" "/dev/sdb5")
+
+export BLK1=/dev/sdb2
+export BLK2=/dev/sdc2
+export BLK3=/dev/sdd2
+
+aux extend_filter_LVMTEST "a|/dev/sdb*|" "a|/dev/sdc*|" "a|/dev/sdd*|"
+aux lvmconf "devices/allow_changes_with_duplicate_pvs = 1"

--- a/test/shell/idm_ilm_fabric_failure.sh
+++ b/test/shell/idm_ilm_fabric_failure.sh
@@ -18,24 +18,12 @@ SKIP_WITH_LVMPOLLD=1
 [ -z "$LVM_TEST_LOCK_TYPE_IDM" ] && skip;
 [ -z "$LVM_TEST_FAILURE_INJECTION" ] && skip;
 
-aux extend_filter_LVMTEST "a|/dev/sdb*|" "a|/dev/sdc*|" "a|/dev/sdd*|"
-aux lvmconf "devices/allow_changes_with_duplicate_pvs = 1"
-
-BLK1=/dev/sdb2
-BLK2=/dev/sdc2
-BLK3=/dev/sdd2
+. lib/idm_setup
+. lib/idm_cleanup
 
 DISK1="$(basename -- ${BLK1%?})"
 DISK2="$(basename -- ${BLK2%?})"
 DISK3="$(basename -- ${BLK3%?})"
-
-# Cleanup devices
-dd if=/dev/zero of="$BLK1" bs=1MB count=1000
-wipefs -a "$BLK1" 2>/dev/null || true
-dd if=/dev/zero of="$BLK2" bs=1MB count=1000
-wipefs -a "$BLK2" 2>/dev/null || true
-dd if=/dev/zero of="$BLK3" bs=1MB count=1000
-wipefs -a "$BLK3" 2>/dev/null || true
 
 vgcreate --shared --locktype idm TESTVG1 $BLK1 $BLK2 $BLK3
 

--- a/test/shell/idm_ilm_fabric_failure_half_brain.sh
+++ b/test/shell/idm_ilm_fabric_failure_half_brain.sh
@@ -18,20 +18,11 @@ SKIP_WITH_LVMPOLLD=1
 [ -z "$LVM_TEST_LOCK_TYPE_IDM" ] && skip;
 [ -z "$LVM_TEST_FAILURE_INJECTION" ] && skip;
 
-aux extend_filter_LVMTEST "a|/dev/sdb*|" "a|/dev/sdj*|"
-aux lvmconf "devices/allow_changes_with_duplicate_pvs = 1"
-
-BLK1=/dev/sdb2
-BLK2=/dev/sdc2
+. lib/idm_setup
+. lib/idm_cleanup
 
 DISK1="$(basename -- ${BLK1%?})"
 DISK2="$(basename -- ${BLK2%?})"
-
-# Cleanup devices
-dd if=/dev/zero of="$BLK1" bs=1MB count=1000
-wipefs -a "$BLK1" 2>/dev/null || true
-dd if=/dev/zero of="$BLK2" bs=1MB count=1000
-wipefs -a "$BLK2" 2>/dev/null || true
 
 vgcreate --shared --locktype idm TESTVG1 $BLK1 $BLK2
 

--- a/test/shell/idm_ilm_fabric_failure_timeout.sh
+++ b/test/shell/idm_ilm_fabric_failure_timeout.sh
@@ -18,20 +18,11 @@ SKIP_WITH_LVMPOLLD=1
 [ -z "$LVM_TEST_LOCK_TYPE_IDM" ] && skip;
 [ -z "$LVM_TEST_FAILURE_INJECTION" ] && skip;
 
-aux extend_filter_LVMTEST "a|/dev/sdb*|" "a|/dev/sdj*|"
-aux lvmconf "devices/allow_changes_with_duplicate_pvs = 1"
-
-BLK1=/dev/sdb2
-BLK2=/dev/sdj2
+. lib/idm_setup
+. lib/idm_cleanup
 
 DISK1="$(basename -- ${BLK1%?})"
 DISK2="$(basename -- ${BLK2%?})"
-
-# Cleanup devices
-dd if=/dev/zero of="$BLK1" bs=1MB count=1000
-wipefs -a "$BLK1" 2>/dev/null || true
-dd if=/dev/zero of="$BLK2" bs=1MB count=1000
-wipefs -a "$BLK2" 2>/dev/null || true
 
 vgcreate --shared --locktype idm TESTVG1 $BLK1 $BLK2
 

--- a/test/shell/idm_lvmlockd_failure.sh
+++ b/test/shell/idm_lvmlockd_failure.sh
@@ -18,11 +18,8 @@ SKIP_WITH_LVMPOLLD=1
 [ -z "$LVM_TEST_LOCK_TYPE_IDM" ] && skip;
 [ -z "$LVM_TEST_FAILURE_INJECTION" ] && skip;
 
-aux extend_filter_LVMTEST "a|/dev/sdb*|" "a|/dev/sdj*|"
-aux lvmconf "devices/allow_changes_with_duplicate_pvs = 1"
-
-BLK1=/dev/sdb2
-BLK2=/dev/sdc2
+. lib/idm_setup
+. lib/idm_cleanup
 
 DISK1="$(basename -- ${BLK1%?})"
 DISK2="$(basename -- ${BLK2%?})"

--- a/test/shell/idm_multi_hosts_lv_ex_timeout_hosta.sh
+++ b/test/shell/idm_multi_hosts_lv_ex_timeout_hosta.sh
@@ -5,22 +5,8 @@ SKIP_WITH_LVMPOLLD=1
 [ -z "$LVM_TEST_LOCK_TYPE_IDM" ] && skip;
 [ -z "$LVM_TEST_MULTI_HOST_IDM" ] && skip;
 
-aux extend_filter_LVMTEST "a|/dev/sdb*|" "a|/dev/sdc*|" "a|/dev/sdd*|"
-aux lvmconf "devices/allow_changes_with_duplicate_pvs = 1"
-
-BLKS=("/dev/sdb2" "/dev/sdb3" "/dev/sdb4" "/dev/sdb5")
-
-for d in "${BLKS[@]}"; do
-	dd if=/dev/zero of="$d" bs=1MB count=1000 || true
-	wipefs -a "$d" 2>/dev/null || true
-done
-
-i=0
-for d in "${BLKS[@]}"; do
-	i=$((i+1))
-	dmsetup remove /dev/TESTVG$i/foo || true
-	dmsetup remove /dev/TESTVG$i || true
-done
+. lib/idm_setup
+. lib/idm_cleanup
 
 i=0
 for d in "${BLKS[@]}"; do

--- a/test/shell/idm_multi_hosts_lv_ex_timeout_hostb.sh
+++ b/test/shell/idm_multi_hosts_lv_ex_timeout_hostb.sh
@@ -5,10 +5,7 @@ SKIP_WITH_LVMPOLLD=1
 [ -z "$LVM_TEST_LOCK_TYPE_IDM" ] && skip;
 [ -z "$LVM_TEST_MULTI_HOST_IDM" ] && skip;
 
-aux extend_filter_LVMTEST "a|/dev/sdb*|" "a|/dev/sdc*|" "a|/dev/sdd*|"
-aux lvmconf "devices/allow_changes_with_duplicate_pvs = 1"
-
-BLKS=("/dev/sdb2" "/dev/sdb3" "/dev/sdb4" "/dev/sdb5")
+. lib/idm_setup
 
 vgchange --lock-start
 

--- a/test/shell/idm_multi_hosts_lv_sh_ex_hosta.sh
+++ b/test/shell/idm_multi_hosts_lv_sh_ex_hosta.sh
@@ -5,32 +5,11 @@ SKIP_WITH_LVMPOLLD=1
 [ -z "$LVM_TEST_LOCK_TYPE_IDM" ] && skip;
 [ -z "$LVM_TEST_MULTI_HOST_IDM" ] && skip;
 
-aux extend_filter_LVMTEST "a|/dev/sdb*|" "a|/dev/sdc*|" "a|/dev/sdd*|"
-aux lvmconf "devices/allow_changes_with_duplicate_pvs = 1"
-
-BLKS=("/dev/sdb2" "/dev/sdb3" "/dev/sdb4" "/dev/sdb5"
-      "/dev/sdc2" "/dev/sdc3" "/dev/sdc4" "/dev/sdc5"
-      "/dev/sdd2" "/dev/sdd3" "/dev/sdd4" "/dev/sdd5")
-
-for d in "${BLKS[@]}"; do
-	dd if=/dev/zero of="$d" bs=1MB count=1000 || true
-	wipefs -a "$d" 2>/dev/null || true
-done
+. lib/idm_setup
+. lib/idm_cleanup
 
 i=0
-for d in "${BLKS[@]}"; do
-	i=$((i+1))
-
-	for j in {1..20}
-	do
-		dmsetup remove /dev/TESTVG$i/foo$j || true
-	done
-
-	dmsetup remove /dev/TESTVG$i || true
-done
-
-i=0
-for d in "${BLKS[@]}"; do
+for d in "${BLKSALL[@]}"; do
 	i=$((i+1))
 	vgcreate --shared --locktype idm TESTVG$i $d
 
@@ -41,7 +20,7 @@ for d in "${BLKS[@]}"; do
 done
 
 i=0
-for d in "${BLKS[@]}"; do
+for d in "${BLKSALL[@]}"; do
 	i=$((i+1))
 
 	for j in {1..20}
@@ -51,7 +30,7 @@ for d in "${BLKS[@]}"; do
 done
 
 i=0
-for d in "${BLKS[@]}"; do
+for d in "${BLKSALL[@]}"; do
 	i=$((i+1))
 
 	for j in {1..20}

--- a/test/shell/idm_multi_hosts_lv_sh_ex_hostb.sh
+++ b/test/shell/idm_multi_hosts_lv_sh_ex_hostb.sh
@@ -5,19 +5,14 @@ SKIP_WITH_LVMPOLLD=1
 [ -z "$LVM_TEST_LOCK_TYPE_IDM" ] && skip;
 [ -z "$LVM_TEST_MULTI_HOST_IDM" ] && skip;
 
-aux extend_filter_LVMTEST "a|/dev/sdb*|" "a|/dev/sdc*|" "a|/dev/sdd*|"
-aux lvmconf "devices/allow_changes_with_duplicate_pvs = 1"
-
-BLKS=("/dev/sdb2" "/dev/sdb3" "/dev/sdb4" "/dev/sdb5"
-      "/dev/sdc2" "/dev/sdc3" "/dev/sdc4" "/dev/sdc5"
-      "/dev/sdd2" "/dev/sdd3" "/dev/sdd4" "/dev/sdd5")
+. lib/idm_setup
 
 vgchange --lock-start
 
 vgdisplay
 
 i=0
-for d in "${BLKS[@]}"; do
+for d in "${BLKSALL[@]}"; do
         i=$((i+1))
 	for j in {1..20}
 	do
@@ -26,7 +21,7 @@ for d in "${BLKS[@]}"; do
 done
 
 i=0
-for d in "${BLKS[@]}"; do
+for d in "${BLKSALL[@]}"; do
         i=$((i+1))
 	for j in {1..20}
 	do
@@ -36,7 +31,7 @@ for d in "${BLKS[@]}"; do
 done
 
 i=0
-for d in "${BLKS[@]}"; do
+for d in "${BLKSALL[@]}"; do
         i=$((i+1))
 	vgremove -f TESTVG$i
 done

--- a/test/shell/idm_multi_hosts_lv_sh_timeout_hosta.sh
+++ b/test/shell/idm_multi_hosts_lv_sh_timeout_hosta.sh
@@ -5,27 +5,11 @@ SKIP_WITH_LVMPOLLD=1
 [ -z "$LVM_TEST_LOCK_TYPE_IDM" ] && skip;
 [ -z "$LVM_TEST_MULTI_HOST_IDM" ] && skip;
 
-aux extend_filter_LVMTEST "a|/dev/sdb*|" "a|/dev/sdc*|" "a|/dev/sdd*|"
-aux lvmconf "devices/allow_changes_with_duplicate_pvs = 1"
-
-BLKS=("/dev/sdb2" "/dev/sdb3" "/dev/sdb4" "/dev/sdb5"
-      "/dev/sdc2" "/dev/sdc3" "/dev/sdc4" "/dev/sdc5"
-      "/dev/sdd2" "/dev/sdd3" "/dev/sdd4" "/dev/sdd5")
-
-for d in "${BLKS[@]}"; do
-	dd if=/dev/zero of="$d" bs=1MB count=1000 || true
-	wipefs -a "$d" 2>/dev/null || true
-done
+. lib/idm_setup
+. lib/idm_cleanup
 
 i=0
-for d in "${BLKS[@]}"; do
-	i=$((i+1))
-	dmsetup remove /dev/TESTVG$i/foo || true
-	dmsetup remove /dev/TESTVG$i || true
-done
-
-i=0
-for d in "${BLKS[@]}"; do
+for d in "${BLKSALL[@]}"; do
 	i=$((i+1))
 	vgcreate --shared --locktype idm TESTVG$i $d
 	lvcreate -a n --zero n -l 1 -n foo TESTVG$i

--- a/test/shell/idm_multi_hosts_lv_sh_timeout_hostb.sh
+++ b/test/shell/idm_multi_hosts_lv_sh_timeout_hostb.sh
@@ -5,19 +5,14 @@ SKIP_WITH_LVMPOLLD=1
 [ -z "$LVM_TEST_LOCK_TYPE_IDM" ] && skip;
 [ -z "$LVM_TEST_MULTI_HOST_IDM" ] && skip;
 
-aux extend_filter_LVMTEST "a|/dev/sdb*|" "a|/dev/sdc*|" "a|/dev/sdd*|"
-aux lvmconf "devices/allow_changes_with_duplicate_pvs = 1"
-
-BLKS=("/dev/sdb2" "/dev/sdb3" "/dev/sdb4" "/dev/sdb5"
-      "/dev/sdc2" "/dev/sdc3" "/dev/sdc4" "/dev/sdc5"
-      "/dev/sdd2" "/dev/sdd3" "/dev/sdd4" "/dev/sdd5")
+. lib/idm_setup
 
 vgchange --lock-start
 
 vgdisplay
 
 i=0
-for d in "${BLKS[@]}"; do
+for d in "${BLKSALL[@]}"; do
         i=$((i+1))
 	lvchange -a sy TESTVG$i/foo
 done
@@ -25,14 +20,14 @@ done
 sleep 80
 
 i=0
-for d in "${BLKS[@]}"; do
+for d in "${BLKSALL[@]}"; do
         i=$((i+1))
 	lvchange -a ey TESTVG$i/foo
 	lvchange -a n TESTVG$i/foo
 done
 
 i=0
-for d in "${BLKS[@]}"; do
+for d in "${BLKSALL[@]}"; do
         i=$((i+1))
 	vgremove -f TESTVG$i
 done

--- a/test/shell/idm_multi_hosts_vg_hosta.sh
+++ b/test/shell/idm_multi_hosts_vg_hosta.sh
@@ -5,26 +5,11 @@ SKIP_WITH_LVMPOLLD=1
 [ -z "$LVM_TEST_LOCK_TYPE_IDM" ] && skip;
 [ -z "$LVM_TEST_MULTI_HOST_IDM" ] && skip;
 
-aux extend_filter_LVMTEST "a|/dev/sdb*|" "a|/dev/sdc*|" "a|/dev/sdd*|"
-
-BLKS=("/dev/sdb2" "/dev/sdb3" "/dev/sdb4" "/dev/sdb5"
-      "/dev/sdc2" "/dev/sdc3" "/dev/sdc4" "/dev/sdc5"
-      "/dev/sdd2" "/dev/sdd3" "/dev/sdd4" "/dev/sdd5")
-
-for d in "${BLKS[@]}"; do
-	dd if=/dev/zero of="$d" bs=1MB count=1000 || true
-	wipefs -a "$d" 2>/dev/null || true
-done
+. lib/idm_setup
+. lib/idm_cleanup
 
 i=0
-for d in "${BLKS[@]}"; do
-	i=$((i+1))
-	dmsetup remove /dev/TESTVG$i/foo || true
-	dmsetup remove /dev/TESTVG$i || true
-done
-
-i=0
-for d in "${BLKS[@]}"; do
+for d in "${BLKSALL[@]}"; do
 	echo $i
 	i=$((i+1))
 	vgcreate --shared --locktype idm TESTVG$i $d

--- a/test/shell/idm_multi_hosts_vg_hostb.sh
+++ b/test/shell/idm_multi_hosts_vg_hostb.sh
@@ -5,19 +5,14 @@ SKIP_WITH_LVMPOLLD=1
 [ -z "$LVM_TEST_LOCK_TYPE_IDM" ] && skip;
 [ -z "$LVM_TEST_MULTI_HOST_IDM" ] && skip;
 
-aux extend_filter_LVMTEST "a|/dev/sdb*|" "a|/dev/sdc*|" "a|/dev/sdd*|"
-
-BLKS=("/dev/sdb2" "/dev/sdb3" "/dev/sdb4" "/dev/sdb5"
-      "/dev/sdc2" "/dev/sdc3" "/dev/sdc4" "/dev/sdc5"
-      "/dev/sdd2" "/dev/sdd3" "/dev/sdd4" "/dev/sdd5")
+. lib/idm_setup
 
 vgchange --lock-start
-
 
 vgdisplay
 
 i=0
-for d in "${BLKS[@]}"; do
+for d in "${BLKSALL[@]}"; do
         i=$((i+1))
 	vgchange -a ey TESTVG$i
 	vgchange -a n TESTVG$i


### PR DESCRIPTION
For fault injection cases and multi host testing, let's use two script
to setup and cleanup the environment:

- lib/idm_setup.sh: contains the drives and device names for the
  testing;
- lib/idm_cleanup.sh: cleanup for the testing VG/LV.

Signed-off-by: Leo Yan <leo.yan@linaro.org>