### PR TITLE
Revert "test: Clean drive firmware in IDM preparation script"

### DIFF
--- a/test/lib/aux.sh
+++ b/test/lib/aux.sh
@@ -950,6 +950,19 @@ prepare_devs() {
 	wait
 	finish_udev_transaction
 
+	if test -n "$LVM_TEST_LOCK_TYPE_IDM" &&
+	   test -z "$LVM_TEST_MULTI_HOST_IDM"; then
+		sg_raw -v -r 512 -o test_data.bin /dev/sg2  88 00 01 00 00 00 00 20 FF 01 00 00 00 01 00 00
+		sg_raw -v -s 512 -i test_data.bin /dev/sg2  8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
+		sg_raw -v -s 512 -i test_data.bin /dev/sg4  8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
+		sg_raw -v -s 512 -i test_data.bin /dev/sg5  8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
+		sg_raw -v -s 512 -i test_data.bin /dev/sg7  8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
+		sg_raw -v -s 512 -i test_data.bin /dev/sg10 8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
+		sg_raw -v -s 512 -i test_data.bin /dev/sg11 8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
+		sg_raw -v -s 512 -i test_data.bin /dev/sg12 8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
+		sg_raw -v -s 512 -i test_data.bin /dev/sg14 8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
+	fi
+
 	if test -n "$LVM_TEST_BACKING_MULTI_DEVICES"; then
 		for d in "${BLK_DEVS[@]}"; do
 			dd if=/dev/zero of="$d" bs=1MB count=1000

--- a/test/shell/aa-lvmlockd-idm-prepare.sh
+++ b/test/shell/aa-lvmlockd-idm-prepare.sh
@@ -18,14 +18,3 @@ test_description='Set up things to run tests with dlm'
 
 aux prepare_idm
 aux prepare_lvmlockd
-
-# Clean up drive firmware
-sg_raw -v -r 512 -o test_data.bin /dev/sg2  88 00 01 00 00 00 00 20 FF 01 00 00 00 01 00 00
-sg_raw -v -s 512 -i test_data.bin /dev/sg2  8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
-sg_raw -v -s 512 -i test_data.bin /dev/sg4  8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
-sg_raw -v -s 512 -i test_data.bin /dev/sg5  8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
-sg_raw -v -s 512 -i test_data.bin /dev/sg7  8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
-sg_raw -v -s 512 -i test_data.bin /dev/sg10 8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
-sg_raw -v -s 512 -i test_data.bin /dev/sg11 8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
-sg_raw -v -s 512 -i test_data.bin /dev/sg12 8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00
-sg_raw -v -s 512 -i test_data.bin /dev/sg14 8E 00 FF 00 00 00 00 00 00 00 00 00 00 01 00 00


### PR DESCRIPTION
This reverts commit e05969abb47af9067f9a6937b6e329be00cc943c.

Since the script aa-lvmlockd-idm-prepare.sh will be used for multi-host
testing, if hostb use the aa-lvmlockd-idm-prepare.sh for initialization,
it also will cleanup the drive firmware context and this is not
expected.  For multi-host testing, hosta firstly run and hostb needs to
test based on hosta's testing result, if hostb executes
aa-lvmlockd-idm-prepare.sh and cleanup drive firmware, this will lead
wrong operations.  So revert this commit.

Signed-off-by: Leo Yan <leo.yan@linaro.org>